### PR TITLE
spread ui schema options

### DIFF
--- a/packages/core/src/models/uischema.ts
+++ b/packages/core/src/models/uischema.ts
@@ -23,6 +23,7 @@
   THE SOFTWARE.
 */
 import { JsonSchema } from './jsonSchema';
+import { UISchemaOptionsMaterial } from './uischemaOptionsMaterial';
 
 /**
  * Interface for describing an UI schema element that is referencing
@@ -137,7 +138,10 @@ export interface UISchemaElement {
   /**
    * Any additional options.
    */
-  options?: { [key: string]: any };
+  options?: {
+    [key: string]: any;
+    material?: UISchemaOptionsMaterial;
+  };
 }
 
 /**

--- a/packages/core/src/models/uischemaOptionsMaterial.ts
+++ b/packages/core/src/models/uischemaOptionsMaterial.ts
@@ -1,0 +1,332 @@
+/*
+  The MIT License
+  
+  Copyright (c) 2017-2019 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+  
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+  
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+  
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+import {
+  AlertProps,
+  AutocompleteProps,
+  AvatarGroupProps,
+  PaginationProps,
+  RatingProps,
+  SkeletonProps,
+  SpeedDialActionProps,
+  SpeedDialIconProps,
+  SpeedDialProps,
+  TabContextProps,
+  TabListProps,
+  TabPanelProps,
+  TimelineConnectorProps,
+  TimelineContentProps,
+  TimelineDotProps,
+  TimelineItemProps,
+  TimelineOppositeContentProps,
+  TimelineProps,
+  TimelineSeparatorProps,
+  ToggleButtonGroupProps,
+  ToggleButtonProps,
+  TreeItemProps,
+  TreeViewProps
+} from '@material-ui/lab';
+import {
+  AccordionActionsProps,
+  AccordionDetailsProps,
+  AccordionSummaryProps,
+  AppBarProps,
+  AvatarProps,
+  BackdropProps,
+  BadgeProps,
+  BottomNavigationProps,
+  BottomNavigationActionProps,
+  BreadcrumbsProps,
+  ButtonProps,
+  ButtonBaseProps,
+  ButtonGroupProps,
+  CardProps,
+  CardActionAreaProps,
+  CardActionsProps,
+  CardContentProps,
+  CardHeaderProps,
+  CardMediaProps,
+  CheckboxProps,
+  ChipProps,
+  CircularProgressProps,
+  ClickAwayListenerProps,
+  CollapseProps,
+  ContainerProps,
+  CssBaselineProps,
+  DialogProps,
+  DialogActionsProps,
+  DialogContentProps,
+  DialogContentTextProps,
+  DialogTitleProps,
+  DividerProps,
+  DrawerProps,
+  ExpansionPanelProps,
+  ExpansionPanelActionsProps,
+  ExpansionPanelDetailsProps,
+  ExpansionPanelSummaryProps,
+  FabProps,
+  FadeProps,
+  FilledInputProps,
+  FormControlProps,
+  FormControlLabelProps,
+  FormGroupProps,
+  FormHelperTextProps,
+  FormLabelProps,
+  GridProps,
+  GridListProps,
+  GridListTileProps,
+  GridListTileBarProps,
+  GrowProps,
+  HiddenProps,
+  IconProps,
+  IconButtonProps,
+  InputProps,
+  InputAdornmentProps,
+  InputBaseProps,
+  InputLabelProps,
+  LinearProgressProps,
+  LinkProps,
+  ListProps,
+  ListItemProps,
+  ListItemAvatarProps,
+  ListItemIconProps,
+  ListItemSecondaryActionProps,
+  ListItemTextProps,
+  ListSubheaderProps,
+  MenuProps,
+  MenuItemProps,
+  MenuListProps,
+  MobileStepperProps,
+  ModalProps,
+  NativeSelectProps,
+  NoSsrProps,
+  OutlinedInputProps,
+  PaperProps,
+  PopoverProps,
+  PopperProps,
+  PortalProps,
+  RadioProps,
+  RadioGroupProps,
+  RootRefProps,
+  SelectProps,
+  SlideProps,
+  SliderProps,
+  SnackbarProps,
+  SnackbarContentProps,
+  StepProps,
+  StepButtonProps,
+  StepConnectorProps,
+  StepContentProps,
+  StepIconProps,
+  StepLabelProps,
+  StepperProps,
+  SvgIconProps,
+  SwipeableDrawerProps,
+  SwitchProps,
+  TabProps,
+  TabScrollButtonProps,
+  TableProps,
+  TableBodyProps,
+  TableCellProps,
+  TableContainerProps,
+  TableFooterProps,
+  TableHeadProps,
+  TablePaginationProps,
+  TableRowProps,
+  TableSortLabelProps,
+  TabsProps,
+  TextFieldProps,
+  TextareaAutosizeProps,
+  ToolbarProps,
+  TooltipProps,
+  TypographyProps,
+  ZoomProps
+} from '@material-ui/core';
+import { MuiPickersUtilsProviderProps } from '@material-ui/pickers/MuiPickersUtilsProvider';
+import {
+  BaseDatePickerProps,
+  DatePickerProps,
+  DatePickerViewsProps,
+  KeyboardDatePickerProps
+} from '@material-ui/pickers/DatePicker';
+import {
+  BaseDateTimePickerProps,
+  DateTimePickerProps,
+  DateTimePickerViewsProps,
+  KeyboardDateTimePickerProps
+} from '@material-ui/pickers/DateTimePicker';
+
+/**
+ * All props from all material ui components.
+ * If using the material renderer set, if the renderer renders any of these material components,
+ * these props will be spread onto it and take precedence over all other props.
+ */
+export interface UISchemaOptionsMaterial {
+  AccordionActionsProps?: AccordionActionsProps;
+  AccordionDetailsProps?: AccordionDetailsProps;
+  AccordionSummaryProps?: AccordionSummaryProps;
+  AlertProps?: AlertProps;
+  AppBarProps?: AppBarProps;
+  AutocompleteProps?: AutocompleteProps<any, any, any, any>;
+  AvatarGroupProps?: AvatarGroupProps;
+  AvatarProps?: AvatarProps;
+  BackdropProps?: BackdropProps;
+  BadgeProps?: BadgeProps;
+  BaseDatePickerProps?: BaseDatePickerProps;
+  BaseDateTimePickerProps?: BaseDateTimePickerProps;
+  BottomNavigationActionProps?: BottomNavigationActionProps;
+  BottomNavigationProps?: BottomNavigationProps;
+  BreadcrumbsProps?: BreadcrumbsProps;
+  ButtonBaseProps?: ButtonBaseProps;
+  ButtonGroupProps?: ButtonGroupProps;
+  ButtonProps?: ButtonProps;
+  CardActionAreaProps?: CardActionAreaProps;
+  CardActionsProps?: CardActionsProps;
+  CardContentProps?: CardContentProps;
+  CardHeaderProps?: CardHeaderProps;
+  CardMediaProps?: CardMediaProps;
+  CardProps?: CardProps;
+  CheckboxProps?: CheckboxProps;
+  ChipProps?: ChipProps;
+  CircularProgressProps?: CircularProgressProps;
+  ClickAwayListenerProps?: ClickAwayListenerProps;
+  CollapseProps?: CollapseProps;
+  ContainerProps?: ContainerProps;
+  CssBaselineProps?: CssBaselineProps;
+  DatePickerProps?: DatePickerProps;
+  DatePickerViewsProps?: DatePickerViewsProps;
+  DateTimePickerProps?: DateTimePickerProps;
+  DateTimePickerViewsProps?: DateTimePickerViewsProps;
+  DialogActionsProps?: DialogActionsProps;
+  DialogContentProps?: DialogContentProps;
+  DialogContentTextProps?: DialogContentTextProps;
+  DialogProps?: DialogProps;
+  DialogTitleProps?: DialogTitleProps;
+  DividerProps?: DividerProps;
+  DrawerProps?: DrawerProps;
+  ExpansionPanelActionsProps?: ExpansionPanelActionsProps;
+  ExpansionPanelDetailsProps?: ExpansionPanelDetailsProps;
+  ExpansionPanelProps?: ExpansionPanelProps;
+  ExpansionPanelSummaryProps?: ExpansionPanelSummaryProps;
+  FabProps?: FabProps;
+  FadeProps?: FadeProps;
+  FilledInputProps?: FilledInputProps;
+  FormControlLabelProps?: FormControlLabelProps;
+  FormControlProps?: FormControlProps;
+  FormGroupProps?: FormGroupProps;
+  FormHelperTextProps?: FormHelperTextProps;
+  FormLabelProps?: FormLabelProps;
+  GridListProps?: GridListProps;
+  GridListTileBarProps?: GridListTileBarProps;
+  GridListTileProps?: GridListTileProps;
+  GridProps?: GridProps;
+  GrowProps?: GrowProps;
+  HiddenProps?: HiddenProps;
+  IconButtonProps?: IconButtonProps;
+  IconProps?: IconProps;
+  InputAdornmentProps?: InputAdornmentProps;
+  InputBaseProps?: InputBaseProps;
+  InputLabelProps?: InputLabelProps;
+  InputProps?: InputProps;
+  KeyboardDatePickerProps?: KeyboardDatePickerProps;
+  KeyboardDateTimePickerProps?: KeyboardDateTimePickerProps;
+  LinearProgressProps?: LinearProgressProps;
+  LinkProps?: LinkProps;
+  ListItemAvatarProps?: ListItemAvatarProps;
+  ListItemIconProps?: ListItemIconProps;
+  ListItemProps?: ListItemProps;
+  ListItemSecondaryActionProps?: ListItemSecondaryActionProps;
+  ListItemTextProps?: ListItemTextProps;
+  ListProps?: ListProps;
+  ListSubheaderProps?: ListSubheaderProps;
+  MenuItemProps?: MenuItemProps;
+  MenuListProps?: MenuListProps;
+  MenuProps?: MenuProps;
+  MobileStepperProps?: MobileStepperProps;
+  ModalProps?: ModalProps;
+  MuiPickersUtilsProviderProps?: MuiPickersUtilsProviderProps;
+  NativeSelectProps?: NativeSelectProps;
+  NoSsrProps?: NoSsrProps;
+  OutlinedInputProps?: OutlinedInputProps;
+  PaginationProps?: PaginationProps;
+  PaperProps?: PaperProps;
+  PopoverProps?: PopoverProps;
+  PopperProps?: PopperProps;
+  PortalProps?: PortalProps;
+  RadioGroupProps?: RadioGroupProps;
+  RadioProps?: RadioProps;
+  RatingProps?: RatingProps;
+  RootRefProps?: RootRefProps;
+  SelectProps?: SelectProps;
+  SkeletonProps?: SkeletonProps;
+  SlideProps?: SlideProps;
+  SliderProps?: SliderProps;
+  SnackbarContentProps?: SnackbarContentProps;
+  SnackbarProps?: SnackbarProps;
+  SpeedDialActionProps?: SpeedDialActionProps;
+  SpeedDialIconProps?: SpeedDialIconProps;
+  SpeedDialProps?: SpeedDialProps;
+  StepButtonProps?: StepButtonProps;
+  StepConnectorProps?: StepConnectorProps;
+  StepContentProps?: StepContentProps;
+  StepIconProps?: StepIconProps;
+  StepLabelProps?: StepLabelProps;
+  StepProps?: StepProps;
+  StepperProps?: StepperProps;
+  SvgIconProps?: SvgIconProps;
+  SwipeableDrawerProps?: SwipeableDrawerProps;
+  SwitchProps?: SwitchProps;
+  TabContextProps?: TabContextProps;
+  TabListProps?: TabListProps;
+  TabPanelProps?: TabPanelProps;
+  TabProps?: TabProps;
+  TabScrollButtonProps?: TabScrollButtonProps;
+  TableBodyProps?: TableBodyProps;
+  TableCellProps?: TableCellProps;
+  TableContainerProps?: TableContainerProps;
+  TableFooterProps?: TableFooterProps;
+  TableHeadProps?: TableHeadProps;
+  TablePaginationProps?: TablePaginationProps;
+  TableProps?: TableProps;
+  TableRowProps?: TableRowProps;
+  TableSortLabelProps?: TableSortLabelProps;
+  TabsProps?: TabsProps;
+  TextFieldProps?: TextFieldProps;
+  TextareaAutosizeProps?: TextareaAutosizeProps;
+  TimelineConnectorProps?: TimelineConnectorProps;
+  TimelineContentProps?: TimelineContentProps;
+  TimelineDotProps?: TimelineDotProps;
+  TimelineItemProps?: TimelineItemProps;
+  TimelineOppositeContentProps?: TimelineOppositeContentProps;
+  TimelineProps?: TimelineProps;
+  TimelineSeparatorProps?: TimelineSeparatorProps;
+  ToggleButtonGroupProps?: ToggleButtonGroupProps;
+  ToggleButtonProps?: ToggleButtonProps;
+  ToolbarProps?: ToolbarProps;
+  TooltipProps?: TooltipProps;
+  TreeItemProps?: TreeItemProps;
+  TreeViewProps?: TreeViewProps;
+  TypographyProps?: TypographyProps;
+  ZoomProps?: ZoomProps;
+}

--- a/packages/core/src/util/uischema.ts
+++ b/packages/core/src/util/uischema.ts
@@ -22,8 +22,10 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
+import { merge } from 'lodash';
 import isEmpty from 'lodash/isEmpty';
 import { isLayout, UISchemaElement } from '../models/uischema';
+import { StatePropsOfRenderer } from './renderer';
 
 export type IterateCallback = (uischema: UISchemaElement) => void;
 
@@ -54,3 +56,9 @@ export const iterateSchema = (
   }
   toApply(uischema);
 };
+
+export const getAppliedUiSchemaOptions = (args: {
+  config: StatePropsOfRenderer['config'];
+  uischema: Pick<UISchemaElement, 'options'>;
+}): Exclude<UISchemaElement['options'], undefined> =>
+  merge({}, args.config, args.uischema.options);

--- a/packages/material/src/controls/MaterialAnyOfStringOrEnumControl.tsx
+++ b/packages/material/src/controls/MaterialAnyOfStringOrEnumControl.tsx
@@ -27,6 +27,7 @@ import {
   ControlProps,
   ControlState,
   EnumCellProps,
+  getAppliedUiSchemaOptions,
   JsonSchema,
   RankedTester,
   rankWith,
@@ -37,7 +38,6 @@ import {
 import { Control, withJsonFormsControlProps } from '@jsonforms/react';
 import { Input } from '@material-ui/core';
 import { InputBaseComponentProps } from '@material-ui/core/InputBase';
-import merge from 'lodash/merge';
 import React from 'react';
 import { MaterialInputControl } from './MaterialInputControl';
 
@@ -64,7 +64,10 @@ const MuiAutocompleteInputText = (props: EnumCellProps & WithClassname) => {
   const enumSchema = findEnumSchema(schema.anyOf);
   const stringSchema = findTextSchema(schema.anyOf);
   const maxLength = stringSchema.maxLength;
-  const appliedUiSchemaOptions = merge({}, config, uischema.options);
+  const appliedUiSchemaOptions = getAppliedUiSchemaOptions({
+    config,
+    uischema
+  });
   let inputProps: InputBaseComponentProps = {};
   if (appliedUiSchemaOptions.restrict) {
     inputProps = { maxLength: maxLength };
@@ -95,6 +98,7 @@ const MuiAutocompleteInputText = (props: EnumCellProps & WithClassname) => {
       inputProps={inputProps}
       error={!isValid}
       endAdornment={dataList}
+      {...appliedUiSchemaOptions.material?.InputProps}
     />
   );
 };

--- a/packages/material/src/controls/MaterialBooleanControl.tsx
+++ b/packages/material/src/controls/MaterialBooleanControl.tsx
@@ -28,7 +28,8 @@ import {
   isBooleanControl,
   RankedTester,
   rankWith,
-  ControlProps
+  ControlProps,
+  getAppliedUiSchemaOptions
 } from '@jsonforms/core';
 import { withJsonFormsControlProps } from '@jsonforms/react';
 import { FormControlLabel, Hidden } from '@material-ui/core';
@@ -48,8 +49,12 @@ export const MaterialBooleanControl = ({
   path,
   config
 }: ControlProps) => {
+  const appliedUiSchemaOptions = getAppliedUiSchemaOptions({
+    config,
+    uischema
+  });
   return (
-    <Hidden xsUp={!visible}>
+    <Hidden xsUp={!visible} {...appliedUiSchemaOptions.material?.HiddenProps}>
       <FormControlLabel
         label={label}
         id={id}
@@ -67,8 +72,10 @@ export const MaterialBooleanControl = ({
             handleChange={handleChange}
             errors={errors}
             config={config}
+            {...appliedUiSchemaOptions.material?.CheckboxProps}
           />
         }
+        {...appliedUiSchemaOptions.material?.FormControlLabelProps}
       />
     </Hidden>
   );

--- a/packages/material/src/controls/MaterialBooleanToggleControl.tsx
+++ b/packages/material/src/controls/MaterialBooleanToggleControl.tsx
@@ -30,7 +30,8 @@ import {
   rankWith,
   ControlProps,
   optionIs,
-  and
+  and,
+  getAppliedUiSchemaOptions
 } from '@jsonforms/core';
 import { withJsonFormsControlProps } from '@jsonforms/react';
 import { FormControlLabel, Hidden } from '@material-ui/core';
@@ -50,8 +51,12 @@ export const MaterialBooleanToggleControl = ({
   path,
   config
 }: ControlProps) => {
+  const appliedUiSchemaOptions = getAppliedUiSchemaOptions({
+    config,
+    uischema
+  });
   return (
-    <Hidden xsUp={!visible}>
+    <Hidden xsUp={!visible} {...appliedUiSchemaOptions.material?.HiddenProps}>
       <FormControlLabel
         label={label}
         id={id}
@@ -69,8 +74,10 @@ export const MaterialBooleanToggleControl = ({
             handleChange={handleChange}
             errors={errors}
             config={config}
+            {...appliedUiSchemaOptions.material?.SwitchProps}
           />
         }
+        {...appliedUiSchemaOptions.material?.FormControlLabelProps}
       />
     </Hidden>
   );

--- a/packages/material/src/controls/MaterialDateControl.tsx
+++ b/packages/material/src/controls/MaterialDateControl.tsx
@@ -23,12 +23,12 @@
   THE SOFTWARE.
 */
 import startsWith from 'lodash/startsWith';
-import merge from 'lodash/merge';
 import React from 'react';
 import {
   computeLabel,
   ControlState,
   DispatchPropsOfControl,
+  getAppliedUiSchemaOptions,
   isDateControl,
   isDescriptionHidden,
   isPlainLabel,
@@ -54,9 +54,7 @@ export interface DateControl {
 }
 
 // Workaround typing problems in @material-ui/pickers@3.2.3
-const AnyPropsKeyboardDatePicker: React.FunctionComponent<
-  any
-> = KeyboardDatePicker;
+const AnyPropsKeyboardDatePicker: React.FunctionComponent<any> = KeyboardDatePicker;
 
 export class MaterialDateControl extends Control<
   StatePropsOfDateControl & DispatchPropsOfControl & DateControl,
@@ -82,7 +80,10 @@ export class MaterialDateControl extends Control<
     const cancelLabel = '%cancel';
     const clearLabel = '%clear';
     const isValid = errors.length === 0;
-    const appliedUiSchemaOptions = merge({}, config, uischema.options);
+    const appliedUiSchemaOptions = getAppliedUiSchemaOptions({
+      config,
+      uischema
+    });
     const showDescription = !isDescriptionHidden(
       visible,
       description,
@@ -109,8 +110,11 @@ export class MaterialDateControl extends Control<
     }
 
     return (
-      <Hidden xsUp={!visible}>
-        <MuiPickersUtilsProvider utils={MomentUtils}>
+      <Hidden xsUp={!visible} {...appliedUiSchemaOptions.material?.HiddenProps}>
+        <MuiPickersUtilsProvider
+          utils={MomentUtils}
+          {...appliedUiSchemaOptions.material?.MuiPickersUtilsProviderProps}
+        >
           <AnyPropsKeyboardDatePicker
             id={id + '-input'}
             label={computeLabel(
@@ -141,6 +145,7 @@ export class MaterialDateControl extends Control<
             rightArrowIcon={<KeyboardArrowRightIcon />}
             keyboardIcon={<EventIcon />}
             InputProps={inputProps}
+            {...appliedUiSchemaOptions.material?.KeyboardDatePickerProps}
           />
         </MuiPickersUtilsProvider>
       </Hidden>

--- a/packages/material/src/controls/MaterialDateTimeControl.tsx
+++ b/packages/material/src/controls/MaterialDateTimeControl.tsx
@@ -48,9 +48,7 @@ import {
 import MomentUtils from '@date-io/moment';
 
 // Workaround typing problems in @material-ui/pickers@3.2.3
-const AnyPropsKeyboardDateTimepicker: React.FunctionComponent<
-  any
-> = KeyboardDateTimePicker;
+const AnyPropsKeyboardDateTimepicker: React.FunctionComponent<any> = KeyboardDateTimePicker;
 
 export class MaterialDateTimeControl extends Control<
   ControlProps,

--- a/packages/material/src/controls/MaterialDateTimeControl.tsx
+++ b/packages/material/src/controls/MaterialDateTimeControl.tsx
@@ -23,11 +23,11 @@
   THE SOFTWARE.
 */
 import React from 'react';
-import merge from 'lodash/merge';
 import {
   computeLabel,
   ControlProps,
   ControlState,
+  getAppliedUiSchemaOptions,
   isDateTimeControl,
   isPlainLabel,
   RankedTester,
@@ -69,13 +69,19 @@ export class MaterialDateTimeControl extends Control<
       data,
       config
     } = this.props;
-    const appliedUiSchemaOptions = merge({}, config, uischema.options);
+    const appliedUiSchemaOptions = getAppliedUiSchemaOptions({
+      config,
+      uischema
+    });
     const isValid = errors.length === 0;
     const inputProps = {};
 
     return (
-      <Hidden xsUp={!visible}>
-        <MuiPickersUtilsProvider utils={MomentUtils}>
+      <Hidden xsUp={!visible} {...appliedUiSchemaOptions.material?.HiddenProps}>
+        <MuiPickersUtilsProvider
+          utils={MomentUtils}
+          {...appliedUiSchemaOptions.material?.MuiPickersUtilsProviderProps}
+        >
           <AnyPropsKeyboardDateTimepicker
             id={id + '-input'}
             label={computeLabel(
@@ -103,6 +109,7 @@ export class MaterialDateTimeControl extends Control<
             keyboardIcon={<EventIcon />}
             timeIcon={<AccessTimeIcon />}
             InputProps={inputProps}
+            {...appliedUiSchemaOptions.material?.KeyboardDateTimePickerProps}
           />
         </MuiPickersUtilsProvider>
       </Hidden>

--- a/packages/material/src/controls/MaterialEnumControl.tsx
+++ b/packages/material/src/controls/MaterialEnumControl.tsx
@@ -28,14 +28,14 @@ import {
   isEnumControl,
   OwnPropsOfEnum,
   RankedTester,
-  rankWith,
+  rankWith
 } from '@jsonforms/core';
 import { withJsonFormsEnumProps } from '@jsonforms/react';
 import { MuiSelect } from '../mui-controls/MuiSelect';
 import { MaterialInputControl } from './MaterialInputControl';
 
 export const MaterialEnumControl = (props: ControlProps & OwnPropsOfEnum) => (
-    <MaterialInputControl {...props} input={MuiSelect} />
+  <MaterialInputControl {...props} input={MuiSelect} />
 );
 
 export const materialEnumControlTester: RankedTester = rankWith(

--- a/packages/material/src/controls/MaterialInputControl.tsx
+++ b/packages/material/src/controls/MaterialInputControl.tsx
@@ -82,10 +82,7 @@ export abstract class MaterialInputControl extends Control<
           onBlur={this.onBlur}
           id={id}
         >
-          <InputLabel
-            htmlFor={id + '-input'}
-            error={!isValid}
-          >
+          <InputLabel htmlFor={id + '-input'} error={!isValid}>
             {computeLabel(
               isPlainLabel(label) ? label : label.default,
               required,

--- a/packages/material/src/controls/MaterialInputControl.tsx
+++ b/packages/material/src/controls/MaterialInputControl.tsx
@@ -27,6 +27,7 @@ import {
   computeLabel,
   ControlProps,
   ControlState,
+  getAppliedUiSchemaOptions,
   isDescriptionHidden,
   isPlainLabel
 } from '@jsonforms/core';
@@ -34,7 +35,6 @@ import { Control } from '@jsonforms/react';
 
 import { Hidden, InputLabel } from '@material-ui/core';
 import { FormControl, FormHelperText } from '@material-ui/core';
-import merge from 'lodash/merge';
 
 export interface WithInput {
   input: any;
@@ -57,7 +57,10 @@ export abstract class MaterialInputControl extends Control<
       input
     } = this.props;
     const isValid = errors.length === 0;
-    const appliedUiSchemaOptions = merge({}, config, uischema.options);
+    const appliedUiSchemaOptions = getAppliedUiSchemaOptions({
+      config,
+      uischema
+    });
 
     const showDescription = !isDescriptionHidden(
       visible,
@@ -75,14 +78,19 @@ export abstract class MaterialInputControl extends Control<
     const InnerComponent = input;
 
     return (
-      <Hidden xsUp={!visible}>
+      <Hidden xsUp={!visible} {...appliedUiSchemaOptions.material?.HiddenProps}>
         <FormControl
           fullWidth={!appliedUiSchemaOptions.trim}
           onFocus={this.onFocus}
           onBlur={this.onBlur}
           id={id}
+          {...appliedUiSchemaOptions.material?.FormControlProps}
         >
-          <InputLabel htmlFor={id + '-input'} error={!isValid}>
+          <InputLabel
+            htmlFor={id + '-input'}
+            error={!isValid}
+            {...appliedUiSchemaOptions.material?.InputLabelProps}
+          >
             {computeLabel(
               isPlainLabel(label) ? label : label.default,
               required,
@@ -95,10 +103,16 @@ export abstract class MaterialInputControl extends Control<
             isValid={isValid}
             visible={visible}
           />
-          <FormHelperText error={!isValid && !showDescription}>
+          <FormHelperText
+            error={!isValid && !showDescription}
+            {...appliedUiSchemaOptions.material?.FormHelperTextProps}
+          >
             {firstFormHelperText}
           </FormHelperText>
-          <FormHelperText error={!isValid}>
+          <FormHelperText
+            error={!isValid}
+            {...appliedUiSchemaOptions.material?.FormHelperTextProps}
+          >
             {secondFormHelperText}
           </FormHelperText>
         </FormControl>

--- a/packages/material/src/controls/MaterialNativeControl.tsx
+++ b/packages/material/src/controls/MaterialNativeControl.tsx
@@ -27,6 +27,7 @@ import {
   computeLabel,
   ControlProps,
   ControlState,
+  getAppliedUiSchemaOptions,
   isDateControl,
   isDescriptionHidden,
   isPlainLabel,
@@ -38,7 +39,6 @@ import {
 import { Hidden } from '@material-ui/core';
 import { Control, withJsonFormsControlProps } from '@jsonforms/react';
 import TextField from '@material-ui/core/TextField';
-import merge from 'lodash/merge';
 
 export class MaterialNativeControl extends Control<ControlProps, ControlState> {
   render() {
@@ -47,6 +47,7 @@ export class MaterialNativeControl extends Control<ControlProps, ControlState> {
       errors,
       label,
       schema,
+      uischema,
       description,
       enabled,
       visible,
@@ -57,11 +58,10 @@ export class MaterialNativeControl extends Control<ControlProps, ControlState> {
       config
     } = this.props;
     const isValid = errors.length === 0;
-    const appliedUiSchemaOptions = merge(
-      {},
+    const appliedUiSchemaOptions = getAppliedUiSchemaOptions({
       config,
-      this.props.uischema.options
-    );
+      uischema
+    });
     const onChange = (ev: any) => handleChange(path, ev.target.value);
     const fieldType = schema.format;
     const showDescription = !isDescriptionHidden(
@@ -72,7 +72,7 @@ export class MaterialNativeControl extends Control<ControlProps, ControlState> {
     );
 
     return (
-      <Hidden xsUp={!visible}>
+      <Hidden xsUp={!visible} {...appliedUiSchemaOptions.material?.HiddenProps}>
         <TextField
           id={id + '-input'}
           label={computeLabel(
@@ -90,6 +90,7 @@ export class MaterialNativeControl extends Control<ControlProps, ControlState> {
           InputLabelProps={{ shrink: true }}
           value={data}
           onChange={onChange}
+          {...appliedUiSchemaOptions.material?.TextFieldProps}
         />
       </Hidden>
     );

--- a/packages/material/src/controls/MaterialOneOfEnumControl.tsx
+++ b/packages/material/src/controls/MaterialOneOfEnumControl.tsx
@@ -28,15 +28,15 @@ import {
   isOneOfEnumControl,
   OwnPropsOfEnum,
   RankedTester,
-  rankWith,
+  rankWith
 } from '@jsonforms/core';
 import { withJsonFormsOneOfEnumProps } from '@jsonforms/react';
 import { MuiSelect } from '../mui-controls/MuiSelect';
 import { MaterialInputControl } from './MaterialInputControl';
 
-export const MaterialOneOfEnumControl = (props: ControlProps & OwnPropsOfEnum) => (
-    <MaterialInputControl {...props} input={MuiSelect} />
-);
+export const MaterialOneOfEnumControl = (
+  props: ControlProps & OwnPropsOfEnum
+) => <MaterialInputControl {...props} input={MuiSelect} />;
 
 export const materialOneOfEnumControlTester: RankedTester = rankWith(
   5,

--- a/packages/material/src/controls/MaterialOneOfRadioGroupControl.tsx
+++ b/packages/material/src/controls/MaterialOneOfRadioGroupControl.tsx
@@ -24,24 +24,26 @@
 */
 import React from 'react';
 import {
-    and,
+  and,
   ControlProps,
   isOneOfEnumControl,
   optionIs,
   OwnPropsOfEnum,
   RankedTester,
-  rankWith,
+  rankWith
 } from '@jsonforms/core';
 import { withJsonFormsOneOfEnumProps } from '@jsonforms/react';
 import { MaterialRadioGroup } from './MaterialRadioGroup';
 
-export const MaterialOneOfRadioGroupControl = (props: ControlProps & OwnPropsOfEnum) => {
-   return <MaterialRadioGroup {...props}/>;
+export const MaterialOneOfRadioGroupControl = (
+  props: ControlProps & OwnPropsOfEnum
+) => {
+  return <MaterialRadioGroup {...props} />;
 };
 
 export const materialOneOfRadioGroupControlTester: RankedTester = rankWith(
-    20,
-    and(isOneOfEnumControl, optionIs('format', 'radio'))
-  );
+  20,
+  and(isOneOfEnumControl, optionIs('format', 'radio'))
+);
 
 export default withJsonFormsOneOfEnumProps(MaterialOneOfRadioGroupControl);

--- a/packages/material/src/controls/MaterialRadioGroup.tsx
+++ b/packages/material/src/controls/MaterialRadioGroup.tsx
@@ -22,12 +22,12 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
-import merge from 'lodash/merge';
 import React from 'react';
 import {
   computeLabel,
   ControlProps,
   ControlState,
+  getAppliedUiSchemaOptions,
   isDescriptionHidden,
   isPlainLabel,
   OwnPropsOfEnum
@@ -52,6 +52,7 @@ export class MaterialRadioGroup extends Control<
       config,
       id,
       label,
+      uischema,
       required,
       description,
       errors,
@@ -60,11 +61,10 @@ export class MaterialRadioGroup extends Control<
       options
     } = this.props;
     const isValid = errors.length === 0;
-    const appliedUiSchemaOptions = merge(
-      {},
+    const appliedUiSchemaOptions = getAppliedUiSchemaOptions({
       config,
-      this.props.uischema.options
-    );
+      uischema
+    });
     const showDescription = !isDescriptionHidden(
       visible,
       description,
@@ -73,15 +73,17 @@ export class MaterialRadioGroup extends Control<
     );
 
     return (
-      <Hidden xsUp={!visible}>
+      <Hidden xsUp={!visible} {...appliedUiSchemaOptions.material?.HiddenProps}>
         <FormControl
           component={'fieldset' as 'div'}
           fullWidth={!appliedUiSchemaOptions.trim}
+          {...appliedUiSchemaOptions.material?.FormControlProps}
         >
           <FormLabel
             htmlFor={id}
             error={!isValid}
             component={'legend' as 'label'}
+            {...appliedUiSchemaOptions.material?.FormLabelProps}
           >
             {computeLabel(
               isPlainLabel(label) ? label : label.default,
@@ -95,12 +97,13 @@ export class MaterialRadioGroup extends Control<
             onChange={(_ev, value) => this.handleChange(value)}
             row={true}
           >
-            {options.map(option => (
+            {options?.map(option => (
               <FormControlLabel
                 value={option.value}
                 key={option.label}
                 control={<Radio checked={data === option.value} />}
                 label={option.label}
+                {...appliedUiSchemaOptions.material?.FormControlLabelProps}
               />
             ))}
           </RadioGroup>

--- a/packages/material/src/controls/MaterialRadioGroupControl.tsx
+++ b/packages/material/src/controls/MaterialRadioGroupControl.tsx
@@ -27,12 +27,17 @@ import {
   and,
   ControlProps,
   isEnumControl,
-  optionIs, OwnPropsOfEnum, RankedTester, rankWith
+  optionIs,
+  OwnPropsOfEnum,
+  RankedTester,
+  rankWith
 } from '@jsonforms/core';
-import {  withJsonFormsEnumProps } from '@jsonforms/react';
+import { withJsonFormsEnumProps } from '@jsonforms/react';
 import { MaterialRadioGroup } from './MaterialRadioGroup';
-export const MaterialRadioGroupControl = (props: ControlProps & OwnPropsOfEnum) => {
-   return <MaterialRadioGroup {...props} />;
+export const MaterialRadioGroupControl = (
+  props: ControlProps & OwnPropsOfEnum
+) => {
+  return <MaterialRadioGroup {...props} />;
 };
 
 export const materialRadioGroupControlTester: RankedTester = rankWith(

--- a/packages/material/src/controls/MaterialSliderControl.tsx
+++ b/packages/material/src/controls/MaterialSliderControl.tsx
@@ -27,6 +27,7 @@ import {
   computeLabel,
   ControlProps,
   ControlState,
+  getAppliedUiSchemaOptions,
   isDescriptionHidden,
   isPlainLabel,
   isRangeControl,
@@ -42,7 +43,6 @@ import {
   Slider,
   Typography
 } from '@material-ui/core';
-import merge from 'lodash/merge';
 
 export class MaterialSliderControl extends Control<ControlProps, ControlState> {
   render() {
@@ -53,6 +53,7 @@ export class MaterialSliderControl extends Control<ControlProps, ControlState> {
       enabled,
       errors,
       label,
+      uischema,
       schema,
       handleChange,
       visible,
@@ -61,11 +62,10 @@ export class MaterialSliderControl extends Control<ControlProps, ControlState> {
       config
     } = this.props;
     const isValid = errors.length === 0;
-    const appliedUiSchemaOptions = merge(
-      {},
+    const appliedUiSchemaOptions = getAppliedUiSchemaOptions({
       config,
-      this.props.uischema.options
-    );
+      uischema
+    });
     const labelStyle: { [x: string]: any } = {
       whiteSpace: 'nowrap',
       overflow: 'hidden',
@@ -89,14 +89,20 @@ export class MaterialSliderControl extends Control<ControlProps, ControlState> {
       appliedUiSchemaOptions.showUnfocusedDescription
     );
     return (
-      <Hidden xsUp={!visible}>
+      <Hidden xsUp={!visible} {...appliedUiSchemaOptions.material?.HiddenProps}>
         <FormControl
           fullWidth={!appliedUiSchemaOptions.trim}
           onFocus={this.onFocus}
           onBlur={this.onBlur}
           id={id}
+          {...appliedUiSchemaOptions.material?.FormControlProps}
         >
-          <Typography id={id + '-typo'} style={labelStyle} variant='caption'>
+          <Typography
+            id={id + '-typo'}
+            style={labelStyle}
+            variant='caption'
+            {...appliedUiSchemaOptions.material?.TypographyProps}
+          >
             {computeLabel(
               isPlainLabel(label) ? label : label.default,
               required,
@@ -104,10 +110,20 @@ export class MaterialSliderControl extends Control<ControlProps, ControlState> {
             )}
           </Typography>
           <div style={rangeContainerStyle}>
-            <Typography style={rangeItemStyle} variant='caption' align='left'>
+            <Typography
+              style={rangeItemStyle}
+              variant='caption'
+              align='left'
+              {...appliedUiSchemaOptions.material?.TypographyProps}
+            >
               {schema.minimum}
             </Typography>
-            <Typography style={rangeItemStyle} variant='caption' align='right'>
+            <Typography
+              style={rangeItemStyle}
+              variant='caption'
+              align='right'
+              {...appliedUiSchemaOptions.material?.TypographyProps}
+            >
               {schema.maximum}
             </Typography>
           </div>
@@ -122,8 +138,12 @@ export class MaterialSliderControl extends Control<ControlProps, ControlState> {
             id={id + '-input'}
             disabled={!enabled}
             step={schema.multipleOf || 1}
+            {...appliedUiSchemaOptions.material?.SliderProps}
           />
-          <FormHelperText error={!isValid}>
+          <FormHelperText
+            error={!isValid}
+            {...appliedUiSchemaOptions.material?.FormHelperTextProps}
+          >
             {!isValid ? errors : showDescription ? description : null}
           </FormHelperText>
         </FormControl>


### PR DESCRIPTION
- Format MaterialDateTimeControl with prettier
- Format MaterialEnumControl with prettier
- Format MaterialInputControl with prettier
- Format MaterialOneOfEnumControl with prettier
- Format MaterialOneOfRadioGroupControl with prettier
- Format MaterialRadioGroupControl with prettier
- Build UISchemaOptionsMaterial type
- Build getAppliedUiSchemaOptions util function
- Spread material schema options into MaterialAnyOfStringOrEnumControl
- Spread material schema options into MaterialBooleanControl
- Spread material schema options into MaterialBooleanToggleControl
- Spread material schema options into MaterialDateControl
- Spread material schema options into MaterialDateTimeControl
- Spread material schema options into MaterialInputControl
- Spread material schema options into MaterialNativeControl
- Spread material schema options into MaterialRadioGroup
- Spread material schema options into MaterialSliderControl
